### PR TITLE
switch Haskell deps to the distribution provided ones

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 FROM hexletbasics/base-image:latest
 
 RUN apt-get update
-RUN apt-get install -y haskell-platform
-
-RUN cabal update && cabal install --package-env=. --lib hspec hspec-contrib QuickCheck HUnit
+RUN apt-get install -y haskell-platform libghc-hspec-expectations-dev
 
 WORKDIR /exercises-haskell
 


### PR DESCRIPTION
Haskell Platform already includes QuickCheck and HUnit, so there is no need to install those packages manually. The "hspec-expectations" package is also present in the apt packages. So I removed the `cabal` invocation. This change will speed a building process up and will reduce disk usage. Also, the whole setup will be more stable and reproducible.